### PR TITLE
bug fix: 修复分类为空时，分类页面无法进入，出现无限加载的问题

### DIFF
--- a/pages/category/category.js
+++ b/pages/category/category.js
@@ -27,7 +27,7 @@ Page({
     }
     this.setData({
       categories: res,
-      selectCategoryId: res[0].id
+      selectCategoryId: res[0] ? res[0].id : 0
     })
     wx.hideLoading()
     this.getGoodsList();


### PR DESCRIPTION
当后台分类为空当时候，小程序的分类页面无法进入，出现无限加载。